### PR TITLE
Netlify redirect everything to root

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+from = "/*"
+to = "/"
+status = 301
+force = false

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,3 @@
 [[redirects]]
 from = "/*"
 to = "/index.html"
-
-[[redirects]]
-from = "/index.html"
-to = "/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[redirects]]
-from = "/*"
-to = "/index.html"
+from = "/**/*"
+to = "/"
 status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,7 @@
 [[redirects]]
-from = "/**/*"
+from = "/*"
+to = "/index.html"
+
+[[redirects]]
+from = "/index.html"
 to = "/"
-status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [[redirects]]
 from = "/*"
-to = "index.html"
+to = "/index.html"
 status = 301

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,4 @@
 [[redirects]]
 from = "/*"
-to = "/"
+to = "index.html"
 status = 301
-force = false


### PR DESCRIPTION
Need all paths on the retirement page host to redirect back to the retirement notice. This will help all previously shared links to the DCC portal to land on the notice instead of a Netlify 404 page.